### PR TITLE
Vjcitn patch 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MultiAssayExperiment
 Title: Software for the integration of multi-omics experiments in Bioconductor
-Version: 1.5.64
+Version: 1.5.64001
 Authors@R: c(person("Marcel", "Ramos", email = "marcel.ramos@roswellpark.org",
     role = c("aut", "cre")),
     person("Levi", "Waldron", email = "lwaldron.research@gmail.com",

--- a/R/upsetSamples.R
+++ b/R/upsetSamples.R
@@ -16,6 +16,7 @@
 #' @examples
 #' data(miniACC)
 #' upsetSamples(miniACC)
+#' upsetSamples(miniACC, nameFilter=function(x)substr(x,1,5))
 #' @return Produces a visualization of set intersections using the UpSet matrix
 #' design
 #' @author Vincent J Carey

--- a/R/upsetSamples.R
+++ b/R/upsetSamples.R
@@ -22,7 +22,7 @@
 #' @export upsetSamples
 upsetSamples <- function(MultiAssayExperiment,
                          nsets=length(MultiAssayExperiment),
-                         nintersects = 24, order.by = "freq", check.names=FALSE, ... ) {
+                         nintersects = 24, order.by = "freq", nameFilter=force, check.names=FALSE, ... ) {
     if (!requireNamespace("UpSetR"))
         stop("Please install the 'UpSetR' package to make venn diagrams")
     maesn <- split(sampleMap(MultiAssayExperiment)[["primary"]],
@@ -33,7 +33,7 @@ upsetSamples <- function(MultiAssayExperiment,
     rownames(incid) <- as.character(st)
     for (i in seq_along(maesn))
         incid[, i] <- 1L*(rownames(incid) %in% maesn[[i]])
-    colnames(incid) <- names(MultiAssayExperiment) # may include hyphens, etc.
+    colnames(incid) <- nameFilter(names(MultiAssayExperiment)) # may include hyphens, etc.
     datf = data.frame(incid, check.names=check.names)
     UpSetR::upset(datf, nsets = nsets, nintersects = nintersects,
                   sets = colnames(incid), order.by = order.by, ...)

--- a/R/upsetSamples.R
+++ b/R/upsetSamples.R
@@ -6,6 +6,12 @@
 #' @inheritParams UpSetR::upset
 #' @param nsets integer number of sets to analyze
 #' @param ... parameters passed to \code{\link[UpSetR]{upset}}
+#' @param nameFilter function, defaulting to force, to manipulate colnames of incidence matrix
+#' @param check.names logical(1) used when incidence matrix is coerced to data.frame for use in UpSetR::upset
+#' @note This function is intended to provide convenient visualization of assay availability configurations in MultiAssayExperiment instances.
+#' The \code{\link[UpSetR]{upset}} function requires data.frame input and has many parameters to tune appearance of the result.
+#' Assay name handling is important for interpretability, and the \code{nameFilter} parameter may be useful to simplify
+#' resulting outputs.
 #'
 #' @examples
 #' data(miniACC)
@@ -16,7 +22,7 @@
 #' @export upsetSamples
 upsetSamples <- function(MultiAssayExperiment,
                          nsets=length(MultiAssayExperiment),
-                         nintersects = 24, order.by = "freq", ... ) {
+                         nintersects = 24, order.by = "freq", check.names=FALSE, ... ) {
     if (!requireNamespace("UpSetR"))
         stop("Please install the 'UpSetR' package to make venn diagrams")
     maesn <- split(sampleMap(MultiAssayExperiment)[["primary"]],
@@ -27,7 +33,8 @@ upsetSamples <- function(MultiAssayExperiment,
     rownames(incid) <- as.character(st)
     for (i in seq_along(maesn))
         incid[, i] <- 1L*(rownames(incid) %in% maesn[[i]])
-    colnames(incid) <- names(MultiAssayExperiment)
-    UpSetR::upset(data.frame(incid), nsets = nsets, nintersects = nintersects,
+    colnames(incid) <- names(MultiAssayExperiment) # may include hyphens, etc.
+    datf = data.frame(incid, check.names=check.names)
+    UpSetR::upset(datf, nsets = nsets, nintersects = nintersects,
                   sets = colnames(incid), order.by = order.by, ...)
 }

--- a/man/upsetSamples.Rd
+++ b/man/upsetSamples.Rd
@@ -6,7 +6,8 @@
 assays, using the upset algorithm in \code{UpSetR}}
 \usage{
 upsetSamples(MultiAssayExperiment, nsets = length(MultiAssayExperiment),
-  nintersects = 24, order.by = "freq", ...)
+  nintersects = 24, order.by = "freq", nameFilter = force,
+  check.names = FALSE, ...)
 }
 \arguments{
 \item{MultiAssayExperiment}{instance of
@@ -18,6 +19,10 @@ upsetSamples(MultiAssayExperiment, nsets = length(MultiAssayExperiment),
 
 \item{order.by}{How the intersections in the matrix should be ordered by. Options include frequency (entered as "freq"), degree, or both in any order.}
 
+\item{nameFilter}{function, defaulting to force, to manipulate colnames of incidence matrix}
+
+\item{check.names}{logical(1) used when incidence matrix is coerced to data.frame for use in UpSetR::upset}
+
 \item{...}{parameters passed to \code{\link[UpSetR]{upset}}}
 }
 \value{
@@ -28,9 +33,16 @@ design
 Create a generalized Venn Diagram analog for sample membership in multiple
 assays, using the upset algorithm in \code{UpSetR}
 }
+\note{
+This function is intended to provide convenient visualization of assay availability configurations in MultiAssayExperiment instances.
+The \code{\link[UpSetR]{upset}} function requires data.frame input and has many parameters to tune appearance of the result.
+Assay name handling is important for interpretability, and the \code{nameFilter} parameter may be useful to simplify
+resulting outputs.
+}
 \examples{
 data(miniACC)
 upsetSamples(miniACC)
+upsetSamples(miniACC, nameFilter=function(x)substr(x,1,5))
 }
 \author{
 Vincent J Carey


### PR DESCRIPTION
I noticed that upsetSamples will misbehave with a curatedTCGAData production, as the latter may have some hyphens in the assay names.  So I have added a nameFilter parameter to the upsetSamples function, and default passage of check.names to FALSE when the data.frame needed by upset is created.  It passes check cleanly in devel.