### PR TITLE
optimization of .harmonize

### DIFF
--- a/R/MultiAssayExperiment-class.R
+++ b/R/MultiAssayExperiment-class.R
@@ -170,10 +170,14 @@ setClass(
                   "colData rownames not in sampleMap 'primary'"))
     }
 
-    experiments <- mendoapply(function(x, idx) {
-        x[, colnames(x) %in% idx, drop=FALSE]
-    }, experiments[assay], experiments_columns[assay])
-
+    ## update experiments
+    unchanged <- Map(identical, experiments_columns[assay], colnames(experiments)[assay])
+    subset_assay <- assay[!as.logical(unchanged)]
+    if (length(subset_assay))
+        experiments <- mendoapply(function(x, idx) {
+            x[, colnames(x) %in% idx, drop = FALSE]
+        }, experiments[subset_assay], experiments_columns[subset_assay])
+    
     if (length(harmony))
         message("harmonizing input:\n  ", paste(harmony, collapse="\n  "))
     list(experiments=experiments, sampleMap=sampleMap, colData=colData)


### PR DESCRIPTION
Hello Marcel, @LiNk-NY 

I'm working with a `MultiAssayExperiment` object that contains many assays and I realized that any call to `experiments<-` always takes a lot of time, while working on `ExperimentList` object is very fast. I saw that a lot of the computational time is eaten up by `.harmonize`. I here have a mock example that illustrates this, where an assay is replaced by the same assay on the data set I am working on: 

```r
## Get the data set
BiocManager::install("scpdata")
library(scpdata)
mae <- specht2019v3()
mae <- as(mae, "MultiAssayExperiment")

## Test
library(microbenchmark)
el <- experiments(mae)
microbenchmark(experiments(mae)[[1]] <- experiments(mae)[[1]],
               el[[1]] <- experiments(mae)[[1]],
               MultiAssayExperiment:::.harmonize(el,
                                                 colData(mae),
                                                 sampleMap(mae)),
               times = 1)
```
```
Unit: milliseconds
                                                                expr         min          lq        mean      median          uq         max neval
                      experiments(mae)[[1]] <- experiments(mae)[[1]] 18337.06081 18337.06081 18337.06081 18337.06081 18337.06081 18337.06081     1
                                    el[[1]] <- experiments(mae)[[1]]    65.29469    65.29469    65.29469    65.29469    65.29469    65.29469     1
 MultiAssayExperiment:::.harmonize(el, colData(mae), sampleMap(mae)) 18547.99283 18547.99283 18547.99283 18547.99283 18547.99283 18547.99283     1
```
This is probably not the best way to assess this, but the point is that `.harmonize` is taking a dramatic proportion of the time. After some profiling of the code, I saw that the [`mendoapply` chunk](https://github.com/waldronlab/MultiAssayExperiment/blob/530480ca68c6ffc941c4d983295869c4265a75e7/R/MultiAssayExperiment-class.R#L173-L175) is taking around 85% of the workload.

In this PR I suggest a small modification that improves the speed of `.harmonize` by 3 or 4x. I however can't run your tests because I can't figure out how to get the example data within the tests... I could successfully run the harmonization tests manually.

Would this be useful to you? Do you see another way to optimize the speed even more, without loss of consistency in the data? 
I think some steps of the harmonization could be skipped if `.harmonize` is not called from within a subsetting function, but I'm not sure about that. I would love to have your input on this. 